### PR TITLE
Ensure template values have correct timezone set

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	Vals = TemplateValues{Time: time.Now().Local(), Date: time.Now().Local().Format("2006. 01. 02")}
+	Vals = TemplateValues{Time: time.Now().In(TZ), Date: time.Now().In(TZ).Format("2006. 01. 02")}
 )
 
 type TemplateValues struct {


### PR DESCRIPTION
Prior to this the daily job which sets the data in the topic for my channels would show whatever date it was in UTC/ whatever the default timezone is (depending on how the bot runs).

This ensures the set timezone is used.